### PR TITLE
Fix JSON syntax error

### DIFF
--- a/authors.json
+++ b/authors.json
@@ -1,16 +1,16 @@
 [
-{
-username: "Harun Mbaabu",
-name: "Harun Mbaabu",
-twitter: "Harun Mbaabu",
-picture: "Not Available",
-bio: "Not Available"
-},
-{
-username: "Vincent Kasozo",
-name: "Vincent Kasozo",
-twitter: "_Vincent Kasozo",
-picture: "Not Available",
-bio: "Software engineer."
-}
+  {
+    "username": "Harun Mbaabu",
+    "name": "Harun Mbaabu",
+    "twitter": "Harun Mbaabu",
+    "picture": "Not Available",
+    "bio": "Not Available"
+  },
+  {
+    "username": "Vincent Kasozo",
+    "name": "Vincent Kasozo",
+    "twitter": "_Vincent Kasozo",
+    "picture": "Not Available",
+    "bio": "Software engineer."
+  }
 ]


### PR DESCRIPTION
## Summary
- correct authors.json syntax so it is valid JSON

## Testing
- `pytest -q`
- `python3 - <<'PY'
import json, sys
json.load(open('authors.json'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6886285a710c832a80c85cb5f4094001